### PR TITLE
Add reminder to update wherever connection error happens

### DIFF
--- a/lib/commands/clone/fetchBluprint/index.js
+++ b/lib/commands/clone/fetchBluprint/index.js
@@ -2,6 +2,7 @@ import getLogger from '../../../utils/getLogger';
 import getParser from './parser';
 import getUserConfig from '../../../utils/getUserConfig';
 import https from 'https';
+import bluprintTokenReminder from '../../../utils/bluprintTokenReminder';
 
 const logger = getLogger();
 
@@ -22,6 +23,8 @@ const fetchBluprint = (url) => {
 
         if (!statusCode || statusCode >= 400) {
           logger.error(`Connection error attempting to access repo.`);
+          bluprintTokenReminder();
+          
           return reject(
             new Error(`HTTP error ${statusCode}: ${res.statusMessage}`)
           );
@@ -40,6 +43,8 @@ const fetchBluprint = (url) => {
       })
       .on('error', (e) => {
         logger.error(`Connection error attempting to access repo.`);
+        bluprintTokenReminder();
+
         reject(e);
       });
   });

--- a/lib/commands/start/fetchBluprint/index.js
+++ b/lib/commands/start/fetchBluprint/index.js
@@ -22,6 +22,8 @@ const fetchBluprint = (url, filterGlobs, mergeJson) => {
 
         if (!statusCode || statusCode >= 400) {
           logger.error(`Connection error attempting to access bluprint repo.`);
+          bluprintTokenReminder();
+          
           return reject(
             new Error(`HTTP error ${statusCode}: ${res.statusMessage}`)
           );
@@ -40,6 +42,8 @@ const fetchBluprint = (url, filterGlobs, mergeJson) => {
       })
       .on('error', (e) => {
         logger.error(`Connection error attempting to access bluprint repo.`);
+        bluprintTokenReminder();
+
         reject(e);
       });
   });

--- a/lib/utils/bluprintTokenReminder.js
+++ b/lib/utils/bluprintTokenReminder.js
@@ -1,0 +1,9 @@
+import getLogger from './getLogger';
+
+const logger = getLogger();
+
+export default () => {
+  logger.warn(`Did you recently update your token and perhaps forgot to add it to bluprint?`);
+  logger.info(`Run this command:`);
+  logger.info(`bluprint token PASTE_YOUR_NEW_TOKEN_HERE`)
+};

--- a/lib/utils/fetchBluprintrc.js
+++ b/lib/utils/fetchBluprintrc.js
@@ -24,6 +24,8 @@ const fetchConfig = async(url) => {
 
         if (!statusCode || statusCode >= 400) {
           logger.error(`Connection error attempting to access bluprint repo.`);
+          bluprintTokenReminder();
+
           return reject(
             new Error(`Error when trying to find .bluprintrc in repo.\nHTTP error ${statusCode}: ${res.statusMessage}`)
           );
@@ -57,6 +59,8 @@ const fetchConfig = async(url) => {
       })
       .on('error', (e) => {
         logger.error(`Connection error attempting to access bluprint repo.`);
+        bluprintTokenReminder();
+        
         reject(e);
       });
   });


### PR DESCRIPTION
@travishartman faced this recently – where he had updated his token everywhere but bluprint's token was something he was unaware of.

Since `bluprint start` is the first thing users might do after a token reset, he suggested it was worth adding some instructions to the connection error message.

Implements the same.