### PR TITLE
Up package.json version to 0.6.6 to match latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reuters-graphics/bluprint",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Dead-easy application scaffolding and CLI.",
   "homepage": "https://github.com/reuters-graphics/bluprint#readme",
   "bugs": {


### PR DESCRIPTION
I believe this minor edit is necessary to bring the source code in line with the latest distribution on [npmjs.com](https://www.npmjs.com/package/@reuters-graphics/bluprint?activeTab=versions).

![Mon Feb  6 04:14:40 PM EST 2023](https://user-images.githubusercontent.com/9993/217089805-2a1a20e3-3f9e-4bb1-9d56-8efecbab02f7.jpg)
