### PR TITLE
Upgrade `hosted-git-info` to support default branches besides master 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reuters-graphics/bluprint",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Dead-easy application scaffolding and CLI.",
   "homepage": "https://github.com/reuters-graphics/bluprint#readme",
   "bugs": {
@@ -68,7 +68,7 @@
     "chalk": "^2.4.2",
     "ejs": "^2.6.1",
     "glob": "^7.1.6",
-    "hosted-git-info": "^3.0.2",
+    "hosted-git-info": "^6.1.1",
     "lodash": "^4.17.15",
     "minimatch": "^3.0.4",
     "mustache": "^4.0.0",

--- a/test/add.js
+++ b/test/add.js
@@ -22,6 +22,7 @@ describe('Test command: add', function() {
 
   it('Adds a new bluprint', async function() {
     await add(null, ['reuters-graphics/test-bluprint']);
+    await add(null, ['datadesk/baker-example-page-template']);
 
     const { bluprints } = JSON.parse(fs.readFileSync(userConfigPath, 'utf-8'));
 

--- a/test/start.js
+++ b/test/start.js
@@ -25,6 +25,11 @@ describe('Test command: start', function() {
           project: 'test-bluprint-parts',
           category: 'codes',
         },
+        'baker example': {
+          user: 'datadesk',
+          project: 'baker-example-page-template',
+          category: 'codes',
+        },
       },
     };
 
@@ -55,6 +60,7 @@ describe('Test command: start', function() {
 
   it('Can take a GitHub repo passed directly to command', async function() {
     await start('reuters-graphics/test-bluprint', []);
+    await start('datadesk/baker-example-page-template', []);
 
     expect(fs.existsSync(resolvePath('deep/file.html'))).to.be(true);
     expect(fs.existsSync(resolvePath('moved/docs.md'))).to.be(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1196,12 +1196,12 @@ hosted-git-info@^2.1.4:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
-hosted-git-info@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.2.tgz#8b7e3bd114b59b51786f8bade0f39ddc80275a97"
-  integrity sha512-ezZMWtHXm7Eb7Rq4Mwnx2vs79WUx2QmRg3+ZqeGroKzfDO+EprOcgRPYghsOP9JuYBfK18VojmRTGCg8Ma+ktw==
+hosted-git-info@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-6.1.1.tgz#629442c7889a69c05de604d52996b74fe6f26d58"
+  integrity sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==
   dependencies:
-    lru-cache "^5.1.1"
+    lru-cache "^7.5.1"
 
 http-cache-semantics@^4.0.0:
   version "4.0.3"
@@ -1561,12 +1561,10 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
-lru-cache@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
-  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
-  dependencies:
-    yallist "^3.0.2"
+lru-cache@^7.5.1:
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.1.tgz#8da8d2f5f59827edb388e63e459ac23d6d408fea"
+  integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==
 
 make-dir@^3.0.0:
   version "3.0.0"
@@ -2656,10 +2654,6 @@ xdg-basedir@^4.0.0:
 y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-
-yallist@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Fixes #36. The tests that fail there should pass in this branch.