### PR TITLE
Cut crufty test

### DIFF
--- a/test/add.js
+++ b/test/add.js
@@ -22,7 +22,6 @@ describe('Test command: add', function() {
 
   it('Adds a new bluprint', async function() {
     await add(null, ['reuters-graphics/test-bluprint']);
-    await add(null, ['datadesk/baker-example-page-template']);
 
     const { bluprints } = JSON.parse(fs.readFileSync(userConfigPath, 'utf-8'));
 

--- a/test/start.js
+++ b/test/start.js
@@ -25,11 +25,6 @@ describe('Test command: start', function() {
           project: 'test-bluprint-parts',
           category: 'codes',
         },
-        'baker example': {
-          user: 'datadesk',
-          project: 'baker-example-page-template',
-          category: 'codes',
-        },
       },
     };
 
@@ -60,7 +55,6 @@ describe('Test command: start', function() {
 
   it('Can take a GitHub repo passed directly to command', async function() {
     await start('reuters-graphics/test-bluprint', []);
-    await start('datadesk/baker-example-page-template', []);
 
     expect(fs.existsSync(resolvePath('deep/file.html'))).to.be(true);
     expect(fs.existsSync(resolvePath('moved/docs.md'))).to.be(true);


### PR DESCRIPTION
I added the tests seen here as I debugged #36. Now that the patch is merged, I think we can cut on the tests, which rely on a third party repo you may not want to support long-term.