### PR TITLE
Sync README tagline with descriptions published elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img src="./logo.svg" width="300" alt="bluprint logo" />
 <br />
 
-The simplest way to scaffold new projects from GitHub templates.
+Dead-easy application scaffolding and CLI.
 
 <br />
 


### PR DESCRIPTION
Since "GitHub templates" are now a [separate branded product](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository) of GitHub, it might be nice to avoid using the term here. This patch addresses the issue by substituting the tagline used elsewhere.